### PR TITLE
[Feature] Add University of Siegen Output

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ Reviewing this file manually tells us a lot about how Nix works!
 
 ## Supported Universities:
 
-| University       | entityID | command                                      |
-| ---------------- | -------- | -------------------------------------------- |
-| Universität Bonn | 5138     | `nix run .#install-eduroam-university-bonn`  |
-| Universität Köln | 5133     | `nix run .#install-eduroam-university-koeln` |
+| University        | entityID | command                                       |
+| ----------------- | -------- | --------------------------------------------- |
+| Universität Bonn  | 5138     | `nix run .#install-eduroam-university-bonn`   |
+| Universität Köln  | 5133     | `nix run .#install-eduroam-university-koeln`  |
+| Universität Siegen| 5356     | `nix run .#install-eduroam-university-siegen` |

--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ Reviewing this file manually tells us a lot about how Nix works!
 
 ## Supported Universities:
 
-| University        | entityID | command                                      |
-| ----------------- | -------- | -------------------------------------------- |
-| Universität Bonn  | 5138     | `nix run .#install-eduroam-university-bonn`  |
-| Universität Köln  | 5133     | `nix run .#install-eduroam-university-koeln` |
-| Universität Siegen| 5356     | `nix run .#install-eduroam-university-koeln` |
+| University        | entityID | command                                       |
+| ----------------- | -------- | --------------------------------------------- |
+| Universität Bonn  | 5138     | `nix run .#install-eduroam-university-bonn`   |
+| Universität Köln  | 5133     | `nix run .#install-eduroam-university-koeln`  |
+| Universität Siegen| 5356     | `nix run .#install-eduroam-university-siegen` |

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ Reviewing this file manually tells us a lot about how Nix works!
 
 ## Supported Universities:
 
-| University       | entityID | command                                      |
-| ---------------- | -------- | -------------------------------------------- |
-| Universität Bonn | 5138     | `nix run .#install-eduroam-university-bonn`  |
-| Universität Köln | 5133     | `nix run .#install-eduroam-university-koeln` |
+| University        | entityID | command                                      |
+| ----------------- | -------- | -------------------------------------------- |
+| Universität Bonn  | 5138     | `nix run .#install-eduroam-university-bonn`  |
+| Universität Köln  | 5133     | `nix run .#install-eduroam-university-koeln` |
+| Universität Siegen| 5356     | `nix run .#install-eduroam-university-koeln` |

--- a/flake.lock
+++ b/flake.lock
@@ -24,6 +24,18 @@
         "url": "https://cat.eduroam.org/user/API.php?action=downloadInstaller&device=linux&generatedfor=user&lang=en&openroaming=0&profile=5133"
       }
     },
+    "eduroam-university-siegen": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-jNkWNKTBTaDt/3EDJdXIW/kFeQpLBvs6YcTECv0/Kb0=",
+        "type": "file",
+        "url": "https://cat.eduroam.org/user/API.php?action=downloadInstaller&device=linux&generatedfor=user&lang=en&openroaming=0&profile=5356"
+      },
+      "original": {
+        "type": "file",
+        "url": "https://cat.eduroam.org/user/API.php?action=downloadInstaller&device=linux&generatedfor=user&lang=en&openroaming=0&profile=5356"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1692638711,
@@ -44,6 +56,7 @@
       "inputs": {
         "eduroam-university-bonn": "eduroam-university-bonn",
         "eduroam-university-koeln": "eduroam-university-koeln",
+        "eduroam-university-siegen": "eduroam-university-siegen",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,10 @@
       url = "https://cat.eduroam.org/user/API.php?action=downloadInstaller&lang=en&profile=5133&device=linux&generatedfor=user&openroaming=0";
       flake = false;
     };
+    eduroam-university-siegen = {
+      url = "https://cat.eduroam.org/user/API.php?action=downloadInstaller&lang=en&profile=5356&device=linux&generatedfor=user&openroaming=0";
+      flake = false;
+    };
   };
 
   outputs = { self, ... }@inputs:
@@ -39,6 +43,10 @@
           # nix run .#install-eduroam-university-bonn
           install-eduroam-university-bonn = pkgs.writeShellScriptBin "install-eduroam-university-bonn"
             "${python-with-dbus}/bin/python3 ${eduroam-university-bonn}";
+
+          # nix run .#install-eduroam-university-bonn
+          install-eduroam-university-siegen = pkgs.writeShellScriptBin "install-eduroam-university-siegen"
+            "${python-with-dbus}/bin/python3 ${eduroam-university-siegen}";
 
           # nix run .#install-eduroam-university-koeln
           install-eduroam-university-koeln = pkgs.writeShellScriptBin "install-eduroam-university-koeln"

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,8 @@
       url = "https://cat.eduroam.org/user/API.php?action=downloadInstaller&lang=en&profile=5133&device=linux&generatedfor=user&openroaming=0";
       flake = false;
     };
+
+    # The Eduroam Python script for the University of Siegen
     eduroam-university-siegen = {
       url = "https://cat.eduroam.org/user/API.php?action=downloadInstaller&lang=en&profile=5356&device=linux&generatedfor=user&openroaming=0";
       flake = false;


### PR DESCRIPTION
I added an output for the university of Siegen. The `entityID` provided by [their API]( https://cat.eduroam.org/user/API.php?action=listAllIdentityProviders&api) doesn't align with the one the [regular page]( https://cat.eduroam.org/user/API.php?action=listAllIdentityProviders&api) queries for some reason. This does work though.