### PR TITLE
Add saarland university

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -12,6 +12,18 @@
         "url": "https://cat.eduroam.org/user/API.php?action=downloadInstaller&device=linux&generatedfor=user&lang=en&openroaming=0&profile=1338"
       }
     },
+    "eduroam-saarland-university": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-WYjWQyWGsYiSu+Xu3w29VcKiQtEegWTy8zJBZ5dCB1U=",
+        "type": "file",
+        "url": "https://cat.eduroam.org/user/API.php?action=downloadInstaller&device=linux&generatedfor=user&lang=en&openroaming=0&profile=10315"
+      },
+      "original": {
+        "type": "file",
+        "url": "https://cat.eduroam.org/user/API.php?action=downloadInstaller&device=linux&generatedfor=user&lang=en&openroaming=0&profile=10315"
+      }
+    },
     "eduroam-university-bonn": {
       "flake": false,
       "locked": {
@@ -67,6 +79,7 @@
     "root": {
       "inputs": {
         "eduroam-lund-university": "eduroam-lund-university",
+        "eduroam-saarland-university": "eduroam-saarland-university",
         "eduroam-university-bonn": "eduroam-university-bonn",
         "eduroam-university-koeln": "eduroam-university-koeln",
         "eduroam-university-siegen": "eduroam-university-siegen",

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,12 @@
       url = "https://cat.eduroam.org/user/API.php?action=downloadInstaller&lang=en&profile=5356&device=linux&generatedfor=user&openroaming=0";
       flake = false;
     };
+
+    # The Eduroam Python script for Saarland University
+    eduroam-saarland-university = {
+      url = "https://cat.eduroam.org/user/API.php?action=downloadInstaller&lang=en&profile=10315&device=linux&generatedfor=user&openroaming=0";
+      flake = false;
+    };
   };
 
   outputs = { self, ... }@inputs:
@@ -64,6 +70,9 @@
           install-eduroam-university-siegen = pkgs.writeShellScriptBin "install-eduroam-university-siegen"
             "${python-with-dbus}/bin/python3 ${eduroam-university-siegen}";
 
+          # nix run .#install-eduroam-saarland-university
+          install-eduroam-saarland-university = pkgs.writeShellScriptBin "install-eduroam-saarland-university"
+            "${python-with-dbus}/bin/python3 ${eduroam-saarland-university}";
         });
     };
 }


### PR DESCRIPTION
I did not yet add something to the readme since I noticed weird behavior with the entityId. I found that the id I get from `nix run .#list-eduroam-entityIDs` is not the one I need to download the saarland university script from. Further, the ID of lund seems to be assigned to a different university now. I get 433 for Lund University. The script download links seem to still be correct. Other university entityIDs like the one from Köln are still correct too.

Maybe we can find a way to fetch all these scripts and then let the user select one. This would reduce code size too, since currently the flake grows by around 10 similar lines per institution.