### PR TITLE
fix: broken hash for university leipzig

### DIFF
--- a/universities.nix
+++ b/universities.nix
@@ -7,7 +7,7 @@
   { name = "bonn"; id = 5133; hash = "sha256-X+eq9TXuCfy8Iea8MjFhk/hk+xRnjtpEPmLZgRCvv0E="; }
   { name = "flensburg"; id = 5188; hash = "sha256-cZecZECAkbzMc8vPOM0DsHh2HkbRxO/AyyOj0sQ7Gmg="; }
   { name = "koeln"; id = 5133; hash = "sha256-X+eq9TXuCfy8Iea8MjFhk/hk+xRnjtpEPmLZgRCvv0E="; }
-  { name = "leipzig"; id = 5674; hash = "sha256-75mHJNXiP+SOeoMQhmfbYm97TqYHVJejxCKeT5l5Qc8="; }
+  { name = "leipzig"; id = 5674; hash = "sha256-TEYTR8TeRNIIZcUx01j9pfedkk0PF5XuXPAVUyI136E="; }
   { name = "lund"; id = 1338; hash = "sha256-Nln7adqpalZkqSM5AOkN2U1CAQ/T3BmJkNEMeDU4YDg="; }
   { name = "saarland"; id = 10315; hash = "sha256-4OvnApFKD3zz0Xh/y7S6C1uRvyhgPCKBYHd/bhnmeeo="; }
   { name = "siegen"; id = 5356; hash = "sha256-qBGoeIWfYvDVZaxK6uEjPdIaKeBll0UYIEtoN8swInk="; }


### PR DESCRIPTION
The hash for the network was broken ... again!

Error output:
```sh
$ nix run 'github:mayniklas/eduroam-flake'#install-eduroam-leipzig
error: hash mismatch in fixed-output derivation '/nix/store/9dc4x6km88f1c63w6857ssdnil6fdhqf-API.php?action=downloadInstaller-lang=en-profile=5674-device=linux-generatedfor=user-openroaming=0.drv':
         specified: sha256-75mHJNXiP+SOeoMQhmfbYm97TqYHVJejxCKeT5l5Qc8=
            got:    sha256-TEYTR8TeRNIIZcUx01j9pfedkk0PF5XuXPAVUyI136E=
error: Cannot build '/nix/store/nsrsiyzz1k6sla1mpaviwmlj258faiq2-install-eduroam-leipzig.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/7n1k1bq8mmdyqn1bq0428rvlbf0miij0-install-eduroam-leipzig
```