### PR TITLE
Automatically create pull requests

### DIFF
--- a/.github/workflows/nix-build.yaml
+++ b/.github/workflows/nix-build.yaml
@@ -33,7 +33,7 @@ jobs:
           author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
           add-paths: universities.nix
           delete-branch: true
-          commit-message: fix: update hashes
+          commit-message: "fix: update hashes"
           title: Updated hashes in universities.nix
           body: |
             Automatic pull request generated with `update.py`.

--- a/.github/workflows/nix-build.yaml
+++ b/.github/workflows/nix-build.yaml
@@ -24,10 +24,19 @@ jobs:
   create-pr:
     runs-on: ubuntu-latest
     needs: build
-    if: needs.build.result == 'failure'
+    if: ${{ always() && needs.build.result == 'failure' }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v5.0.0
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31.8.0
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
       - name: Rebuild with Python
-        run: ./update.py
+        run: |
+          nix-shell -p "python3.withPackages (ps: with ps; [ requests ])" --run "python update.py"
 
       - name: Create Pull Request
         if: 

--- a/.github/workflows/nix-build.yaml
+++ b/.github/workflows/nix-build.yaml
@@ -21,14 +21,19 @@ jobs:
       - name: Check Flake
         run: nix flake check --all-systems
 
+  create-pr:
+    runs-on: ubuntu-latest
+    needs: build
+    if: needs.build.result == 'failure'
+    steps:
       - name: Rebuild with Python
-        if: failure()
         run: ./update.py
 
       - name: Create Pull Request
+        if: 
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
           add-paths: universities.nix

--- a/.github/workflows/nix-build.yaml
+++ b/.github/workflows/nix-build.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Rebuild with Python
         run: |
-          nix-shell -p "python3.withPackages (ps: with ps; [ requests ])" --run "python update.py"
+          ./update.py
 
       - name: Create Pull Request
         if: 

--- a/.github/workflows/nix-build.yaml
+++ b/.github/workflows/nix-build.yaml
@@ -20,3 +20,25 @@ jobs:
 
       - name: Check Flake
         run: nix flake check --all-systems
+
+      - name: Rebuild with Python
+        if: failure()
+        run: ./update.py
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.PAT }}
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
+          add-paths: universities.nix
+          delete-branch: true
+          commit-message: fix: update hashes
+          title: Updated hashes in universities.nix
+          body: |
+            Automatic pull request generated with `update.py`.
+          labels: |
+            bug
+          assignees: MayNiklas
+          reviewers: MayNiklas
+          draft: false


### PR DESCRIPTION
This pr adds the `create-pr` job to the nix build. This job is only run if the nix build fails. It will automatically execute the python script and commit the changes. You can see a live example here: https://github.com/Kiyotoko/eduroam-flake/pull/1 (don't mind the force push).

> [!warning]
> This action will use your GitHub credentials to create the pull request. Please double check it!